### PR TITLE
Link Linux curses lib

### DIFF
--- a/Makefile.src
+++ b/Makefile.src
@@ -6,7 +6,7 @@ OBJECTS+=${EXTRA_OBJECTS}
 all: ${BINARY}
 
 ${BINARY}: ${OBJECTS}
-	${CC} ${CURSESLIB} ${LDFLAGS} -o ${BINARY} ${OBJECTS}
+	${CC} ${LDFLAGS} -o ${BINARY} ${OBJECTS} ${CURSESLIB} 
 
 install: ${BINARY}
 	install -d -m 755 ${PREFIX}/bin

--- a/configure
+++ b/configure
@@ -165,7 +165,7 @@ cat <<EOF > fake_curses.c
 #include <curses.h>
 main() { initscr(); }
 EOF
-if ! ${CC} ${CURSESLIB} fake_curses.c -o /dev/null 1>/dev/null 2>/dev/null; then
+if ! ${CC} fake_curses.c -o /dev/null ${CURSESLIB} 1>/dev/null 2>/dev/null; then
 	stuff_not_found "No curses headers found (try to install ncurses-dev)"
 fi
 echo found


### PR DESCRIPTION
Tested in both Ubuntu 12.04, kernel 3.2.0 and Mac OS X Darwin 12.1.0.
