### PR TITLE
Change password file mode after saving

### DIFF
--- a/gpg.c
+++ b/gpg.c
@@ -210,6 +210,10 @@ gpg_encrypt(char *tmp_path)
 
 	if (link(new_tmp_path, mbs_passwords_path) != 0)
 		err(1, "gpg_encrypt link(new_tmp_path, password_path)");
+	else {
+		if(chmod(mbs_passwords_path, S_IRUSR | S_IWUSR) !=0)
+			err(1, "chmod error.");
+	}
 
 	if (unlink(new_tmp_path) != 0)
 		err(1, "gpg_encrypt unlink(new_tmp_path)");


### PR DESCRIPTION
Right now, after I saved the password, its mode changed to 664. But when we use `mdp -e` to edit it, it expects its mode to be 600. The problem happens when run `gpg -r xxxxxx -e xxxxx` to encrypt the temp file. The mode for the output gpg file is 664. I didn't find any options in gpg to configure the output file mode. What I did was to call chmod to change the password file mode after the physical link.
