### PR TITLE
mdp: fix gcc-10 build failure (-fno-common)

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -20,8 +20,8 @@
 #include <stdbool.h>
 
 extern bool		 cfg_backup;
-unsigned int		 cfg_character_count;
-wchar_t			*cfg_character_set;
+extern unsigned int	 cfg_character_count;
+extern wchar_t		*cfg_character_set;
 extern char		*cfg_config_path;
 extern char		*cfg_editor;
 extern char		*cfg_gpg_path;


### PR DESCRIPTION
gcc-10 changed the default from -fcommon to fno-common:
  https://gcc.gnu.org/PR85678

As a result build fails as:

    ld: editor.o:(.bss+0x8): multiple definition of `cfg_character_set'; config.o:(.bss+0x20): first defined here
    ld: editor.o:(.bss+0x10): multiple definition of `cfg_character_count'; config.o:(.data+0x10): first defined here

The change marks all variables as external one.